### PR TITLE
Add dynamic reconfigure server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,16 @@ find_package(catkin REQUIRED COMPONENTS
   nodelet
   cv_bridge
   camera_info_manager
+  dynamic_reconfigure
 )
 
 find_package(OpenCV REQUIRED)
+
+# Add Dynamic Reconfigure params
+generate_dynamic_reconfigure_options(
+  cfg/azure_kinect_params.cfg
+)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -58,7 +65,7 @@ add_executable(${PROJECT_NAME}_node
   src/k4a_ros_device_params.cpp
   src/k4a_calibration_transform_data.cpp
   )
-
+add_dependencies(${PROJECT_NAME}_node ${PROJECT_NAME}_gencfg)
 target_compile_features(${PROJECT_NAME}_node PUBLIC cxx_std_11)
 
 add_library(${PROJECT_NAME}_nodelet
@@ -67,7 +74,7 @@ add_library(${PROJECT_NAME}_nodelet
   src/k4a_ros_device_params.cpp
   src/k4a_calibration_transform_data.cpp
   )
-
+add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_gencfg)
 target_compile_features(${PROJECT_NAME}_nodelet PUBLIC cxx_std_11)
 
 ## Rename C++ executable without prefix

--- a/cfg/azure_kinect_params.cfg
+++ b/cfg/azure_kinect_params.cfg
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+PACKAGE = "azure_kinect_ros_driver"
+
+
+gen = ParameterGenerator()
+
+gen.add("exposure_time",  int_t,  0,
+        "Exposure time (microsecs)", 15625,  488, 1000000)
+gen.add("brightness",  int_t,  0, "Camera brightness", 128,  0, 255)
+gen.add("contrast",  int_t,  0, "Camera contrast", 5,  0, 10)
+gen.add("saturation",  int_t,  0, "Camera saturation", 32,  0, 63)
+gen.add("sharpness",  int_t,  0,  "Camera sharpness", 2,  0, 4)
+gen.add("white_balance",  int_t,  0,
+        "Camera white balance. Values are rounded to the nearest evenly divisible by 10 degrees", 4500,  2500, 12500)
+gen.add("backlight_compensation", bool_t, 0,
+        "Enable/disable backlight compensation",  False)
+gen.add("color_control_gain",  int_t,  0,
+        "Camera color control gain", 0,  0, 255)
+
+exit(gen.generate(PACKAGE, "AzureKinectRosDevice", "AzureKinectParams"))

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -12,6 +12,8 @@
 
 // Library headers
 //
+#include <azure_kinect_ros_driver/AzureKinectParamsConfig.h>
+#include <dynamic_reconfigure/server.h>
 #include <image_transport/image_transport.h>
 #include <k4a/k4a.h>
 #include <ros/ros.h>
@@ -80,6 +82,9 @@ class K4AROSDevice
   // available.
   void initializeTimestampOffset(const std::chrono::microseconds& k4a_device_timestamp_us);
 
+  // Dynamic reconfigure callback for device
+  void reconfigureCallback(azure_kinect_ros_driver::AzureKinectParamsConfig &config, uint32_t level);
+
   // ROS Node variables
   ros::NodeHandle node_;
   ros::NodeHandle private_node_;
@@ -108,6 +113,7 @@ class K4AROSDevice
 
   std::shared_ptr<camera_info_manager::CameraInfoManager> ci_mngr_rgb_, ci_mngr_ir_;
 
+  dynamic_reconfigure::Server<azure_kinect_ros_driver::AzureKinectParamsConfig> reconfigure_server_;
 
   // Parameters
   K4AROSDeviceParams params_;

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <depend>xacro</depend>
   <depend>cv_bridge</depend>
   <depend>libopencv-dev</depend>
+  <depend>dynamic_reconfigure</depend>
 
   <exec_depend>rgbd_launch</exec_depend>
 


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
Fixes #2578

### Description of the changes:
- Adds a dynamic reconfigure server
  - The server allows modifying most of the values the camera allows to configure
  - Below is an image of the available configs through the testing app of the camera to compare:
![available_configs](https://user-images.githubusercontent.com/21263985/233435187-f5ec3e8b-a1e4-4f00-8f57-a9ef466162ae.png)


<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Run `roslaunch azure_kinect_ros_driver plusone.launch`
- Open image viewer: `rosrun rqt_image_viewer rqt_image_viewer`
- Test the configurations running `rosrun rqt_reconfigure rqt_reconfigure`
