### PR TITLE
Auto-generated cfg name should match file basename

### DIFF
--- a/cfg/azure_kinect_params.cfg
+++ b/cfg/azure_kinect_params.cfg
@@ -18,4 +18,4 @@ gen.add("backlight_compensation", bool_t, 0,
 gen.add("color_control_gain",  int_t,  0,
         "Camera color control gain", 0,  0, 255)
 
-exit(gen.generate(PACKAGE, "AzureKinectRosDevice", "AzureKinectParams"))
+exit(gen.generate(PACKAGE, "AzureKinectRosDevice", "azure_kinect_params"))


### PR DESCRIPTION
Per http://wiki.ros.org/dynamic_reconfigure/Tutorials/HowToWriteYourFirstCfgFile, package generation should use the name of the file minus the extension.

![image](https://user-images.githubusercontent.com/46970345/234719281-ce82a85b-a939-4260-91e0-542a47071a5c.png)
