### PR TITLE
Rename camera topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(OpenCV REQUIRED)
 
 # Add Dynamic Reconfigure params
 generate_dynamic_reconfigure_options(
-  cfg/azure_kinect_params.cfg
+  cfg/AzureKinectParams.cfg
 )
 
 ###################################
@@ -127,7 +127,7 @@ if(MSVC AND NOT k4abt_FOUND)
       )
 
       file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${KBT}")
-        execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/kbt.nuget" 
+        execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/kbt.nuget"
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${KBT}"
       )
 
@@ -176,7 +176,7 @@ if(MSVC AND NOT k4abt_FOUND)
       )
 
       file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${KBT_DEPENDENCIES}")
-        execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/kbtd.nuget" 
+        execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/kbtd.nuget"
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${KBT_DEPENDENCIES}"
       )
 
@@ -199,10 +199,10 @@ if(MSVC AND NOT k4abt_FOUND)
 
       file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CUDNN_DEPENDENCIES}")
 
-      execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/cudnn.nuget" 
+      execute_process(COMMAND tar xvzf "${CMAKE_CURRENT_BINARY_DIR}/cudnn.nuget"
                   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CUDNN_DEPENDENCIES}"
                   )
-      
+
       file(GLOB CUDNN_DLLS
       "${CMAKE_CURRENT_BINARY_DIR}/${CUDNN_DEPENDENCIES}/lib/native/amd64/release/*.dll"
       )

--- a/cfg/AzureKinectParams.cfg
+++ b/cfg/AzureKinectParams.cfg
@@ -18,4 +18,4 @@ gen.add("backlight_compensation", bool_t, 0,
 gen.add("color_control_gain",  int_t,  0,
         "Camera color control gain", 0,  0, 255)
 
-exit(gen.generate(PACKAGE, "AzureKinectRosDevice", "azure_kinect_params"))
+exit(gen.generate(PACKAGE, "AzureKinectRosDevice", "AzureKinectParams"))

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -141,8 +141,8 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
   }
   rgb_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/camera_info", 1);
 
-  static const std::string depth_raw_topic = "depth/image_raw";
-  static const std::string depth_rect_topic = "depth_to_rgb/image_raw";
+  static const std::string depth_raw_topic = "depth/raw/image";
+  static const std::string depth_rect_topic = "depth/rect/image";
   if (params_.depth_unit == sensor_msgs::image_encodings::TYPE_16UC1) {
     // set lowest PNG compression for maximum FPS
     node_.setParam(node_.resolveName(depth_raw_topic) + "/compressed/format", "png");
@@ -152,16 +152,16 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
   }
 
   depth_raw_publisher_ = image_transport_.advertise(depth_raw_topic, 1);
-  depth_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth/camera_info", 1);
+  depth_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth/raw/camera_info", 1);
 
   depth_rect_publisher_ = image_transport_.advertise(depth_rect_topic, 1);
-  depth_rect_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth_to_rgb/camera_info", 1);
+  depth_rect_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth/rect/camera_info", 1);
 
-  rgb_rect_publisher_ = image_transport_.advertise("rgb_to_depth/image_raw", 1);
-  rgb_rect_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb_to_depth/camera_info", 1);
+  rgb_rect_publisher_ = image_transport_.advertise("rgb/rect/image", 1);
+  rgb_rect_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/rect/camera_info", 1);
 
-  ir_raw_publisher_ = image_transport_.advertise("ir/image_raw", 1);
-  ir_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("ir/camera_info", 1);
+  ir_raw_publisher_ = image_transport_.advertise("ir/raw/image", 1);
+  ir_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("ir/raw/camera_info", 1);
 
   if (params_.point_cloud || params_.rgb_point_cloud) {
     pointcloud_publisher_ = node_.advertise<PointCloud2>("points2", 1);

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -137,9 +137,9 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
 
   if (params_.color_format == "bgra")
   {
-    rgb_raw_publisher_ = image_transport_.advertise("rgb/image_raw", 1);
+    rgb_raw_publisher_ = image_transport_.advertise("rgb/raw/image", 1);
   }
-  rgb_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/camera_info", 1);
+  rgb_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/raw/camera_info", 1);
 
   static const std::string depth_raw_topic = "depth/raw/image";
   static const std::string depth_rect_topic = "depth/rect/image";


### PR DESCRIPTION
# What does this MR do?

* Renames `cfg/azure_kinect_params.cfg` to `cfg/AzureKinectParams.cfg` to avoid changing header file imports. This also fixes build issues I attempted to fix in https://github.com/plusone-robotics/Azure_Kinect_ROS_Driver/pull/2.
* Renames depth and rgb topics to avoid collisions with +1 product
* Remove trailing whitespaces in CMakeLists.txt