### PR TITLE
Use an enum for exposure time

### DIFF
--- a/cfg/AzureKinectParams.cfg
+++ b/cfg/AzureKinectParams.cfg
@@ -5,8 +5,29 @@ PACKAGE = "azure_kinect_ros_driver"
 
 gen = ParameterGenerator()
 
+# (name, param type, reconfigure level, description, default, min, max)
+
+exposure_level = gen.enum(
+    [
+        gen.const("488us", int_t, 488, "488 us"),
+        gen.const("1ms", int_t, 977, "977 us"),
+        gen.const("2ms", int_t, 1953, "2 ms"),
+        gen.const("4ms", int_t, 3906, "4 ms"),
+        gen.const("8ms", int_t, 7813, "8 ms"),
+        gen.const("16ms", int_t, 15625, "16 ms"),
+        gen.const("31ms", int_t, 31250, "31 ms"),
+        gen.const("62ms", int_t, 62500, "62 ms"),
+        gen.const("125ms", int_t, 125000, "125 ms"),
+        gen.const("250ms", int_t, 250000, "250 ms"),
+        gen.const("500ms", int_t, 500000, "500 ms"),
+        gen.const("1s", int_t, 1000000, "1 s"),
+        gen.const("2s", int_t, 2000000, "2 s")
+    ], "An enumeration to set exposure level"
+)
+
 gen.add("exposure_time",  int_t,  0,
-        "Exposure time (microsecs)", 15625,  488, 1000000)
+        "Exposure time (microsecs). Times which exceed refresh rate will be capped.", 15625,  488, 2000000,
+        edit_method=exposure_level)
 gen.add("brightness",  int_t,  0, "Camera brightness", 128,  0, 255)
 gen.add("contrast",  int_t,  0, "Camera contrast", 5,  0, 10)
 gen.add("saturation",  int_t,  0, "Camera saturation", 32,  0, 63)


### PR DESCRIPTION
# What does this PR do?

Changes the `exposure_time` dynamic parameter to set using an enumeration. This matches how Microsoft bins the exposure value when [setting manually](https://learn.microsoft.com/en-us/azure/kinect-dk/hardware-specification#rgb-camera-exposure-time-values).

# Screenshots

![image](https://github.com/plusone-robotics/Azure_Kinect_ROS_Driver/assets/46970345/987e89bb-eb60-416f-a3e4-39b7f66c9b69)


![exposure-dropdown](https://github.com/plusone-robotics/Azure_Kinect_ROS_Driver/assets/46970345/8494bee0-13c6-4770-8d90-2c976d0da461)
